### PR TITLE
Changed the colour of ENL ant-trails, made dashes asymmetric.

### DIFF
--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -24,7 +24,8 @@
 window.PLAYER_TRACKER_MAX_TIME = 3*60*60*1000; // in milliseconds
 window.PLAYER_TRACKER_MIN_ZOOM = 9;
 window.PLAYER_TRACKER_MIN_OPACITY = 0.3;
-window.PLAYER_TRACKER_LINE_COLOUR = '#FF00FD';
+window.PLAYER_TRACKER_RES_LINE_COLOUR = '#FF00FD';
+window.PLAYER_TRACKER_ENL_LINE_COLOUR = '#45A000';
 
 
 // use own namespace for plugin
@@ -424,10 +425,10 @@ window.plugin.playerTracker.drawData = function() {
 
     var opts = {
       weight: 2-0.25*i,
-      color: PLAYER_TRACKER_LINE_COLOUR,
+      color: PLAYER_TRACKER_ENL_LINE_COLOUR,
       clickable: false,
       opacity: 1-0.2*i,
-      dashArray: "5,8"
+      dashArray: "5,8,1,3"
     };
 
     $.each(polyLine,function(ind,poly) {
@@ -439,10 +440,10 @@ window.plugin.playerTracker.drawData = function() {
 
     var opts = {
       weight: 2-0.25*i,
-      color: PLAYER_TRACKER_LINE_COLOUR,
+      color: PLAYER_TRACKER_RES_LINE_COLOUR,
       clickable: false,
       opacity: 1-0.2*i,
-      dashArray: "5,8"
+      dashArray: "5,8,1,3"
     };
 
     $.each(polyLine, function(ind,poly) {


### PR DESCRIPTION
Changed the colour of the ENL ant-trail in order to make it easier to distinguish between ENL and RES agents when trying to coordinate events.
Made the dash-pattern slightly asymetric so that it would be possible-ish to determine which way players move (and arrow would be better but that would be a bigger change).